### PR TITLE
chore: Revert "chore: add builder-*base images for machine learning and ml gpu"

### DIFF
--- a/builder-base/Dockerfile.machinelearningbase
+++ b/builder-base/Dockerfile.machinelearningbase
@@ -1,2 +1,0 @@
-FROM jenkinsxio/builder-machine-learning-baseimage:0.0.22
-

--- a/builder-base/Dockerfile.machinelearninggpubase
+++ b/builder-base/Dockerfile.machinelearninggpubase
@@ -1,2 +1,0 @@
-FROM jenkinsxio/builder-machine-learning-gpu-baseimage:0.0.22
-

--- a/builder-base/build-ng.sh
+++ b/builder-base/build-ng.sh
@@ -21,5 +21,3 @@ function build_image {
 
 build_image "ruby" "rubybase"
 build_image "swift" "swiftbase"
-build_image "machinelearning" "machinelearningbase"
-build_image "machinelearninggpu" "machinelearninggpubase"

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -20,8 +20,7 @@ pipelineConfig:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /builder/home/kaniko-secret.json
             steps:
-            - name: kaniko-secret
-              image: jenkinsxio/jx:1.3.963
+            - image: jenkinsxio/jx:1.3.963
               command: jx
               args:
                 - step
@@ -60,24 +59,6 @@ pipelineConfig:
               args:
                 - --dockerfile=/workspace/source/builder-base/Dockerfile.swift.generated
                 - --destination=gcr.io/jenkinsxio/builder-swiftbase:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-base
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-base/Dockerfile.machinelearning.generated
-                - --destination=gcr.io/jenkinsxio/builder-machine-learningbase:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-gpu-base
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-base/Dockerfile.machinelearninggpu.generated
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpubase:${inputs.params.version}
                 - --context=/workspace/source
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true
@@ -110,8 +91,7 @@ pipelineConfig:
               - name: GIT_AUTHOR_NAME
                 value: jenkins-x-bot
             steps:
-            - name: kaniko-scret
-              image: jenkinsxio/jx:1.3.963
+            - image: jenkinsxio/jx:1.3.963
               command: jx
               args:
                 - step
@@ -122,7 +102,6 @@ pipelineConfig:
                 - kaniko-secret
                 - -f
                 - /builder/home/kaniko-secret.json
-
             # build base images
             - name: build-base
               image: centos:7
@@ -150,24 +129,6 @@ pipelineConfig:
               args:
                 - --dockerfile=/workspace/source/builder-base/Dockerfile.swift.generated
                 - --destination=gcr.io/jenkinsxio/builder-swiftbase:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-base
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-base/Dockerfile.machinelearning.generated
-                - --destination=gcr.io/jenkinsxio/builder-machine-learningbase:${inputs.params.version}
-                - --context=/workspace/source
-                - --cache-repo=gcr.io/jenkinsxio/cache
-                - --cache=true
-                - --cache-dir=/workspace
-            - name: build-and-push-machine-learning-gpu-base
-              command: /kaniko/executor
-              args:
-                - --dockerfile=/workspace/source/builder-base/Dockerfile.machinelearninggpu.generated
-                - --destination=gcr.io/jenkinsxio/builder-machine-learning-gpubase:${inputs.params.version}
                 - --context=/workspace/source
                 - --cache-repo=gcr.io/jenkinsxio/cache
                 - --cache=true

--- a/update-bot.sh
+++ b/update-bot.sh
@@ -9,12 +9,8 @@ updatebot push-regex -r \
 	'FROM\sgcr.io/jenkinsxio/builder-base:(.*)' \
 	'FROM\sgcr.io/jenkinsxio/builder-rubybase:(.*)' \
 	'FROM\sgcr.io/jenkinsxio/builder-swiftbase:(.*)' \
-	'FROM\sgcr.io/jenkinsxio/builder-machinelearningbase:(.*)' \
-	'FROM\sgcr.io/jenkinsxio/builder-machinelearninggpubase:(.*)' \
 	'\s+-\s--image=gcr.io/jenkinsxio/builder-base:(.*)' \
 	'\s+-\s--image=gcr.io/jenkinsxio/builder-rubybase:(.*)' \
 	'\s+-\s--image=gcr.io/jenkinsxio/builder-swiftbase:(.*)' \
-	'\s+-\s--image=gcr.io/jenkinsxio/builder-machinelearningbase:(.*)' \
-	'\s+-\s--image=gcr.io/jenkinsxio/builder-machinelearninggpubase:(.*)' \
 	-v ${VERSION} \
 	 \*/Dockerfile jenkins-x.yml


### PR DESCRIPTION
This reverts commit feaea45194cc62126f058dd893d13cba061a3f5d.

This doesn't actually seem to help anything and may make things worse,
so let's stop.