### PR TITLE
fix: Switch to version stream for builders

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -139,10 +139,10 @@ pipelineConfig:
 
             # Create the release notes
             - name: changelog
-              image: gcr.io/jenkinsxio/builder-go:0.1.811
+              image: gcr.io/jenkinsxio/builder-go
               command: ./changelog.sh
 
             # update downstream dependencies
             - name: update-bot
-              image: gcr.io/jenkinsxio/builder-maven:0.1.811
+              image: gcr.io/jenkinsxio/builder-maven
               command: ./update-bot.sh


### PR DESCRIPTION
Specifically to pick up https://github.com/jenkins-x/jx/pull/5691 but
doing this generally is just a good idea.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>