### PR TITLE
chore: Pre-populate binary deps in to jx_home/bin

### DIFF
--- a/builder-base/Dockerfile.common
+++ b/builder-base/Dockerfile.common
@@ -78,6 +78,9 @@ RUN curl -f https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKE
   curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/${EKSCTL_VERSION}/eksctl_Linux_amd64.tar.gz" | tar xz -C /tmp && \
   mv /tmp/eksctl /usr/local/bin
 
-ENV PATH ${PATH}:/opt/google/chrome
+ENV PATH /home/jenkins/.jx/bin:${PATH}:/opt/google/chrome
+
+# TODO: Remove deps downloaded above that are now included in jx bin
+COPY builder-base/deps/bin/* /home/jenkins/.jx/bin/
 
 CMD ["helm","version"]

--- a/builder-base/build-ng.sh
+++ b/builder-base/build-ng.sh
@@ -8,6 +8,12 @@ cat /workspace/source/builder-base/Dockerfile > /workspace/source/builder-base/D
 cat /workspace/source/Dockerfile.common >> /workspace/source/builder-base/Dockerfile.base.generated
 cat /workspace/source/builder-base/Dockerfile.common >> /workspace/source/builder-base/Dockerfile.base.generated
 
+export JX_HOME=/workspace/source/builder-base/deps
+jx install dependencies --all
+unset JX_HOME
+
+ls -la /workspace/source/builder-base/deps/bin/
+
 function build_image {
   name=$1
   base=$2

--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -35,7 +35,7 @@ pipelineConfig:
 
             # build base images
             - name: build-base
-              image: centos:7
+              image: gcr.io/jenkinsxio/builder-go:0.0.0-SNAPSHOT-PR-7104-79
               command: /workspace/source/builder-base/build-ng.sh
             - name: build-and-push-base
               command: /kaniko/executor
@@ -107,7 +107,7 @@ pipelineConfig:
 
             # build base images
             - name: build-base
-              image: centos:7
+              image: gcr.io/jenkinsxio/builder-go:0.0.0-SNAPSHOT-PR-7104-79
               command: /workspace/source/builder-base/build-ng.sh
             - name: build-and-push-base
               command: /kaniko/executor


### PR DESCRIPTION
Part of https://github.com/jenkins-x/jx/issues/6912 - This pull request caches certain jx binary dependencies in ~/.jx/bin in the builders